### PR TITLE
wget on my kodi doesn't support https, curl does

### DIFF
--- a/vpnbook
+++ b/vpnbook
@@ -42,7 +42,7 @@ EOF
 
 download_site() {
 	local site="$1"
-	wget "$site" -q -O -
+	curl "$site" -s
 }
 
 extract_credentials() {


### PR DESCRIPTION
Running kodi 14.2 (Compiled Mar 31 2015) on OpenELEC 5.0.8 has no ssl support for wget. Curl does, so changed wget to curl.

Apparently vpnbook's site is redirecting http to https, so the wget on my Kodi/OpenELEC fails. This does the trick on my Kodi/OpenELEC, and probably on others too 😁 